### PR TITLE
Downgrade KDE runtime to 5.15-22.08

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -1,8 +1,8 @@
 id: io.github.martinrotter.rssguard
 runtime: org.kde.Platform
-runtime-version: '6.3'
+runtime-version: '5.15-22.08'
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.3'
+base-version: '5.15-22.08'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
@@ -20,26 +20,10 @@ finish-args:
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 modules:
-  # TODO: Remove the following module once we update to the 6.4 SDK.
-  # See also: https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/26
-  - name: qt6-core5compat
-    buildsystem: cmake-ninja
-    builddir: true
-    sources:
-      - type: archive
-        url: https://download.qt.io/official_releases/qt/6.3/6.3.2/submodules/qt5compat-everywhere-src-6.3.2.tar.xz
-        sha256: 91a3ac0f3f87e4103afa5834ccbecff9374daf716fab362d0c5e2d6ab98560cc
-    post-install:
-      - ln -sr /app/lib/${FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so* -t /app/lib
-    cleanup:
-      - /include
-      - /mkspecs
-      - /modules
-
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:
-      - -DBUILD_WITH_QT6=ON
+      - -DBUILD_WITH_QT6=OFF
       - -DFORCE_BUNDLE_ICONS=ON
       - -DIS_FLATPAK_BUILD=ON
       - -DNO_UPDATE_CHECK=ON


### PR DESCRIPTION
If I remember correctly, the only real reason we were using the KDE 6 runtime in the first place, was because of a bad file descriptor leak that would happen whenever we hovered the mouse cursor over any clickable URLs in the article viewer panel.

This issue can still be reproduced with the official AppImage, which still bundles Qt 5.15.4 from Ubuntu 20.04.

However, because the KDE runtime 5.15 for Flatpak uses a more recent version of Qt 5, this particular issue has been fixed already.

More details here: https://github.com/flathub/io.github.martinrotter.rssguardlite/pull/8

Closes #5