### PR TITLE
Switch build to Qt6

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -1,8 +1,8 @@
 id: io.github.martinrotter.rssguard
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: 6.7
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-23.08
+base-version: 6.7
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
@@ -190,7 +190,7 @@ modules:
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:
-      - -DBUILD_WITH_QT6=OFF
+      - -DBUILD_WITH_QT6=ON
       - -DENABLE_COMPRESSED_SITEMAP=ON
       - -DENABLE_MEDIAPLAYER_LIBMPV=ON
       - -DENABLE_MEDIAPLAYER_QTMULTIMEDIA=OFF


### PR DESCRIPTION
Hi, since Qt6 has proper fractional scaling on wayland it'd be worth to upgrade the runtime.
EDIT: Currently depends on https://github.com/flathub/io.qt.qtwebengine.BaseApp/pull/346 being merged.