### PR TITLE
Allow UPower access through the system message bus

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -18,6 +18,7 @@ finish-args:
   - --filesystem=xdg-download
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
+  - --system-talk-name=org.freedesktop.UPower
 
 cleanup:
   - /lib/*.a


### PR DESCRIPTION
This silences the following error displayed by Chromium (through QtWebEngine), which is actually spammed multiple times:

```
[2:84:0418/105802.697959:ERROR:bus.cc(399)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```

I think Chromium uses this permission to control screen inhibition, or something like that.