### PR TITLE
libmpv: pin version to `<0.39.0`

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -40,11 +40,12 @@ modules:
         url: https://api.github.com/repos/mpv-player/mpv/tarball/v0.38.0
         sha256: 0170b7e314de7ca5104832f29fcba09cb680e9dd7bdeaaa9f1521ce60d6f9bb0
         x-checker-data:
-          type: json
-          url: https://api.github.com/repos/mpv-player/mpv/releases/latest
-          tag-query: .tag_name
-          version-query: $tag | sub("^v"; "")
-          url-query: .tarball_url
+          type: anitya
+          project-id: 5348
+          stable-only: true
+          url-template: https://api.github.com/repos/mpv-player/mpv/tarball/v$version
+          versions:
+            <: 0.39.0
       - type: patch
         path: patches/context_drm_egl-guard-gbm_device-on-uninit.patch
     cleanup:


### PR DESCRIPTION
Version 0.39.0 requires FFmpeg 6.1, but the current KDE runtime includes FFmpeg 6.0.

This will be revisited when the KDE runtime updates to the newly-released Freedesktop Runtime 24.08, which includes FFmpeg 7.0.

Closes #84