### PR TITLE
Update luajit and clang-format modules

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -179,8 +179,8 @@ modules:
       - install -Dt /app/bin builddir/bin/clang-format
     sources:
       - type: archive
-        url: https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.5/llvm-project-19.1.5.src.tar.xz
-        sha256: bd8445f554aae33d50d3212a15e993a667c0ad1b694ac1977f3463db3338e542
+        url: https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.6/llvm-project-19.1.6.src.tar.xz
+        sha256: e3f79317adaa9196d2cfffe1c869d7c100b7540832bc44fe0d3f44a12861fa34
         x-checker-data:
           type: json
           url: https://api.github.com/repos/llvm/llvm-project/releases/latest


### PR DESCRIPTION
luajit: Update luajit2.git to 2.1-20241113
clang-format: Update llvm-project-19.1.5.src.tar.xz to 19.1.6

Closes #107