### PR TITLE
Revert "Update KDE runtime to 6.9"

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -1,8 +1,8 @@
 id: io.github.martinrotter.rssguard
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.8'
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.9'
+base-version: '6.8'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20


### PR DESCRIPTION
Something in this update broke QtWebEngine rendering in some configurations:

https://redirect.github.com/martinrotter/rssguard/issues/1832

Go back to 6.8 for the time being.

This reverts commit b97e615c8ecdf24ac55855691449aebfabde1e61.