### PR TITLE
Grant access to xdg-config/autostart.

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -16,6 +16,7 @@ finish-args:
   - --socket=pulseaudio
   - --socket=wayland
   - --filesystem=xdg-download
+  - --filesystem=xdg-config/autostart
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   - --system-talk-name=org.freedesktop.UPower


### PR DESCRIPTION
This is needed for the built-in autostart toggle.